### PR TITLE
ci: add Tier A security baseline (gitleaks, pr-title, actionlint, dep-review)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewer for everything in this repo.
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+*       @nischal94

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,25 @@
+---
+name: Bug report
+about: Something doesn't work as expected
+labels: bug
+---
+
+## Description
+
+<!-- What happened? What did you expect to happen? -->
+
+## Reproduction
+
+1.
+2.
+3.
+
+## Environment
+
+- Version / commit:
+- OS:
+- Runtime (Node / Python / etc):
+
+## Logs / screenshots
+
+<!-- Paste relevant output. Strip any secrets. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an enhancement
+labels: enhancement
+---
+
+## Problem
+
+<!-- What user-facing problem does this solve? -->
+
+## Proposed solution
+
+<!-- What would the ideal behavior look like? -->
+
+## Alternatives considered
+
+<!-- Other approaches and why this one is preferred. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What & Why
+
+<!-- One-paragraph summary. Explain intent (why) — the diff shows what. -->
+
+## How
+
+<!-- Key implementation choices. Trade-offs considered. Anything reviewers should look at first. -->
+
+## Test plan
+
+- [ ]
+- [ ]
+
+## Checklist
+
+- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`, `perf:`, `build:`, `ci:`)
+- [ ] Tests pass locally
+- [ ] No secrets, debug statements, or commented-out code in the diff
+- [ ] Docs updated if behavior changed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+
+# Dependabot configuration for the template. By default only GitHub Actions
+# updates are enabled — they're language-agnostic and always safe.
+#
+# When using this template for a real project, uncomment the ecosystem
+# block(s) matching your stack. WARNING: enabling on a stale repo will
+# produce a burst of upgrade PRs immediately. Set open-pull-requests-limit
+# low (1-2) at first if the repo has many outdated deps.
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+
+  # - package-ecosystem: "pip"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   open-pull-requests-limit: 5
+  #   labels: ["dependencies"]
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #     include: "scope"
+
+  # - package-ecosystem: "npm"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #     day: "monday"
+  #   open-pull-requests-limit: 5
+  #   labels: ["dependencies"]
+  #   commit-message:
+  #     prefix: "chore(deps)"
+  #     include: "scope"
+
+  # - package-ecosystem: "docker"
+  #   directory: "/"
+  #   schedule:
+  #     interval: "weekly"
+  #   labels: ["dependencies", "docker"]

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,31 @@
+name: actionlint
+
+# Static analysis for GitHub Actions workflow YAML. Catches typos in
+# expressions, undefined contexts, unsafe shell patterns, and broken
+# `if:` conditions BEFORE they fail at runtime in some unlucky branch.
+#
+# Only runs when workflow files themselves change — nothing to lint
+# otherwise.
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run actionlint
+        run: |
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,41 @@
+name: Dependency Review
+
+# Blocks PRs that introduce dependencies with known vulnerabilities or
+# disallowed licenses. Different from Dependabot — this is a PRE-MERGE
+# gate, while Dependabot only opens upgrade PRs AFTER a vuln is shipped.
+#
+# Only runs when a PR actually changes a manifest. Free on public repos.
+
+on:
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/pnpm-lock.yaml"
+      - "**/yarn.lock"
+      - "**/requirements*.txt"
+      - "**/pyproject.toml"
+      - "**/uv.lock"
+      - "**/Pipfile.lock"
+      - "**/poetry.lock"
+      - "**/go.mod"
+      - "**/go.sum"
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - "**/Gemfile.lock"
+      - "**/composer.lock"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: dependency-review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,28 @@
+name: gitleaks
+
+# Scans the PR diff (and on push, the full history) for committed secrets.
+# Complements GitHub's native secret scanning — gitleaks catches custom
+# patterns and runs at PR-time so leaks are caught BEFORE merge.
+#
+# Free for personal accounts and public repos. For private orgs, gitleaks
+# requires a license key (see https://gitleaks.io/products.html).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,38 @@
+name: PR Title Lint
+
+# Enforces Conventional Commits on PR titles. Prerequisite for any
+# auto-changelog / release-please setup — non-conventional titles silently
+# disappear from the changelog because the commit parser can't classify them.
+#
+# Uses pull_request_target so the action has write permission to set a status
+# check on the PR (safe — only reads the title, never checks out PR code).
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  lint:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            perf
+            build
+            ci
+            style
+            revert

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,17 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities via GitHub's [private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability) feature on this repository:
+
+1. Open the **Security** tab.
+2. Click **Report a vulnerability**.
+3. Fill in the advisory form.
+
+You will receive a response acknowledging the report within 7 days.
+
+**Do not file public issues for security vulnerabilities.**
+
+## Scope
+
+This policy covers the code in this repository. Vulnerabilities in upstream dependencies should be reported to the respective project.


### PR DESCRIPTION
## Summary

Replicates the standard security baseline from [nischal94/repo-template](https://github.com/nischal94/repo-template) into this repo.

### Workflows added
| Workflow | Trigger | Mode |
|---|---|---|
| `gitleaks` | every PR + push to default | blocking |
| `pr-title` | PR open/edit | blocking (enforces Conventional Commits) |
| `actionlint` | when `.github/workflows/` changes | blocking |
| `dependency-review` | when manifests change | blocking (high-severity threshold) |

### Community files added
`SECURITY.md`, `CODEOWNERS`, PR + issue templates, `dependabot.yml` (github-actions ecosystem enabled).

### Existing files untouched
Any pre-existing `claude.yml`, `LICENSE`, etc are preserved as-is.

### After merge
1. Settings → Branches → require status checks: `gitleaks`, `Validate PR title`, `actionlint`, plus 1 approving review and conversation resolution.
2. (Optional) Edit `.github/dependabot.yml` to uncomment `pip` / `npm` / `docker` blocks for this repo's stack.