### PR TITLE
ci: enable npm Dependabot with grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,21 @@ updates:
   #   schedule:
   #     interval: "weekly"
   #   labels: ["dependencies", "docker"]
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels: ["dependencies", "javascript"]
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns: ["*"]
+      npm-minor-patch:
+        applies-to: version-updates
+        update-types: ["minor", "patch"]


### PR DESCRIPTION
Activates the `npm` ecosystem in `.github/dependabot.yml` with grouping configured (security-updates → 1 grouped PR/week, minor/patch → 1 grouped PR/week, majors stay individual).

Solves the Dependabot burst problem documented in CLAUDE.md scar — instead of N separate PRs, expect 1-3 grouped PRs/week per ecosystem.

See [`docs/SECURITY-OPERATIONS.md §5`](https://github.com/nischal94/repo-template/blob/main/docs/SECURITY-OPERATIONS.md#5-dependabot-operations) for the rationale.