### PR TITLE
chore(ci): add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,33 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs that are safe by semver:
+#   * patch updates on any dep
+#   * minor updates on dev-only deps
+#
+# All other Dependabot PRs (prod minors, all majors) require human
+# review. CI must pass before merge — auto-merge respects required
+# status checks.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36 # v3.0.0
+      - name: Auto-merge eligible updates
+        if: |
+          steps.meta.outputs.update-type == 'version-update:semver-patch' ||
+          (steps.meta.outputs.update-type == 'version-update:semver-minor' &&
+           steps.meta.outputs.dependency-type == 'direct:development')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds the same Dependabot auto-merge workflow that already exists in [sonar](https://github.com/nischal94/sonar/blob/main/.github/workflows/dependabot-automerge.yml). It auto-merges Dependabot PRs that are safe by semver:

- **Patch updates** on any dep
- **Minor updates** on dev-only deps

All other Dependabot PRs (prod minors, all majors) still require human review. The workflow uses `gh pr merge --auto`, which queues the merge to fire only after required CI checks pass — broken updates do NOT auto-merge.

## Why now

Part of the post-audit cleanup (see [nischal94/.github decommission notice](https://github.com/nischal94/.github#%EF%B8%8F-decommissioned-2026-05-19)). With cross-repo policy enforcement gone, each repo configures its own automation. This is one of those.

## Effect on existing Dependabot backlog

This workflow only fires on **new** Dependabot PRs after merge. To trigger auto-merge on existing open PRs, comment `@dependabot recreate` on each one — the recreated PR will go through the new logic.

## Test plan
- [ ] Workflow YAML parses (actionlint check)
- [ ] No new required checks introduced (workflow runs but does not block merges)
- [ ] On next Dependabot patch PR: confirm auto-merge fires after CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated handling of eligible dependency updates to streamline the update process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nischal94/anewvibecanvas/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->